### PR TITLE
Remove extra ';' in tinytiffhighrestimer.cpp

### DIFF
--- a/tinytiffhighrestimer.cpp
+++ b/tinytiffhighrestimer.cpp
@@ -47,7 +47,7 @@ void HighResTimer::start(){
   #else
       gettimeofday(&last,0);
   #endif
-};
+}
 
 double HighResTimer::get_time(){
   #ifdef __LINUX__
@@ -67,7 +67,7 @@ double HighResTimer::get_time(){
 
 
   #endif
-};
+}
 
 
 void HighResTimer::test(double* mean, double* stddev, unsigned long* histogram, double* histogram_x, unsigned long histogram_size){
@@ -113,4 +113,4 @@ void HighResTimer::test(double* mean, double* stddev, unsigned long* histogram, 
   }
   *stddev=sqrt(*stddev);
   free(h);
-};
+}


### PR DESCRIPTION
Remove extra ';' in tinytiffhighrestimer.cpp that are causing [-Wpedantic] warnings when I compile TinyTIFF with pedantic warnings.

.../TinyTIFF/tinytiffhighrestimer.cpp:50:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
.../TinyTIFF/tinytiffhighrestimer.cpp:70:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
.../TinyTIFF/tinytiffhighrestimer.cpp:116:2: warning: extra ‘;’ [-Wpedantic]
 };