### PR TITLE
fix msvc build error

### DIFF
--- a/src/tinytiffreader.c
+++ b/src/tinytiffreader.c
@@ -56,7 +56,11 @@
 
 #ifdef TINYTIFF_USE_WINAPI_FOR_FILEIO
 #  include <windows.h>
-#  warning COMPILING TinyTIFFReader with WinAPI
+#  ifdef _MSC_VER
+#    pragma message(__FILE__ "(): COMPILING TinyTIFFWriter with WinAPI")
+#  else
+#    warning COMPILING TinyTIFFWriter with WinAPI
+#  endif // _MSC_VER
 #  define TinyTIFFReader_POSTYPE DWORD
 #else
 #  define TinyTIFFReader_POSTYPE fpos_t

--- a/src/tinytiffwriter.c
+++ b/src/tinytiffwriter.c
@@ -50,7 +50,11 @@
 
 #ifdef TINYTIFF_USE_WINAPI_FOR_FILEIO
 #  include <windows.h>
-#  warning COMPILING TinyTIFFWriter with WinAPI
+#  ifdef _MSC_VER
+#    pragma message(__FILE__ "(): COMPILING TinyTIFFWriter with WinAPI")
+#  else
+#    warning COMPILING TinyTIFFWriter with WinAPI
+#  endif // _MSC_VER
 #  define TinyTIFFWriter_POSTYPE DWORD
 #else
 #  define TinyTIFFWriter_POSTYPE fpos_t


### PR DESCRIPTION
The MSVC preprocessor does not support the ```#warning``` command. Therefore, the compilation process may fail with the following error: ```C1021: invalid preprocessor command 'warning'```. 

I have fixed this issue according with this [docs](https://learn.microsoft.com/en-us/cpp/preprocessor/message?view=msvc-170). 

Now, the code is more cross-platform compatible.
