### PR TITLE
Fix wrong cmake version requirement causing confusion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.23)
 
 set(lib_name "TinyTIFF")
 set(lib_nameXX "TinyTIFFXX")


### PR DESCRIPTION
## Problem Statement:
The newly introduced target_sources handling in the CMakeLists.txt (from version [3.0.0.0 to 4.0.0.0](https://github.com/jkriege2/TinyTIFF/compare/3.0.0.0...4.0.0.0#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4)) cause that building for cmake lower 3.23 is no longer possible. Compare to https://cmake.org/cmake/help/latest/command/target_sources.html#file-sets

## Why to fix:
Currently a lot of errors get thrown in cmake generation step when trying to generate with cmake version > 3.23. These errors however do not allow for easy identification of the underlying issue.

## Proposed fix:
Stating correct minimal verison of cmake for easier identification of the error.

## Related Issues:
This issue is probably related to this: #31 